### PR TITLE
web: Handle non-UTF-8 text uploads gracefully instead of 500

### DIFF
--- a/bobashare-web/src/views/display.rs
+++ b/bobashare-web/src/views/display.rs
@@ -144,10 +144,10 @@ pub async fn display(
                         .unwrap_or_else(|| state.syntax_set.find_syntax_plain_text());
                     // should be alright to assume that 1,048,576 fits in usize on relevant
                     // platforms
-                    let mut contents = String::with_capacity(size as usize);
+                    let mut bytes = Vec::with_capacity(size as usize);
                     upload
                         .file
-                        .read_to_string(&mut contents)
+                        .read_to_end(&mut bytes)
                         .await
                         .map_err(|e| ErrorTemplate {
                             state: tmpl_state.clone(),
@@ -155,46 +155,58 @@ pub async fn display(
                             message: format!("error reading file contents: {e}"),
                         })?;
 
-                    event!(
-                        Level::DEBUG,
-                        "highlighting file with syntax {}",
-                        syntax.name
-                    );
-                    let highlighted = {
-                        let mut generator = ClassedHTMLGenerator::new_with_class_style(
-                            syntax,
-                            &state.syntax_set,
-                            CLASS_STYLE,
-                        );
-                        for line in LinesWithEndings::from(&contents) {
-                            generator
-                                .parse_html_for_line_which_includes_newline(line)
-                                .map_err(|e| ErrorTemplate {
-                                    state: tmpl_state.clone(),
-                                    code: StatusCode::INTERNAL_SERVER_ERROR,
-                                    message: format!("error highlighting file contents: {e}"),
-                                })?;
-                        }
-                        generator.finalize()
-                    };
+                    // Plaintext uploads aren't guaranteed to be UTF-8. If this
+                    // one isn't, fall back to the generic download view instead
+                    // of returning a 500.
+                    match String::from_utf8(bytes) {
+                        Ok(contents) => {
+                            event!(
+                                Level::DEBUG,
+                                "highlighting file with syntax {}",
+                                syntax.name
+                            );
+                            let highlighted = {
+                                let mut generator = ClassedHTMLGenerator::new_with_class_style(
+                                    syntax,
+                                    &state.syntax_set,
+                                    CLASS_STYLE,
+                                );
+                                for line in LinesWithEndings::from(&contents) {
+                                    generator
+                                        .parse_html_for_line_which_includes_newline(line)
+                                        .map_err(|e| ErrorTemplate {
+                                            state: tmpl_state.clone(),
+                                            code: StatusCode::INTERNAL_SERVER_ERROR,
+                                            message: format!(
+                                                "error highlighting file contents: {e}"
+                                            ),
+                                        })?;
+                                }
+                                generator.finalize()
+                            };
 
-                    if extension.eq_ignore_ascii_case("md") {
-                        let displayed = render_markdown_with_syntax_set(
-                            &contents,
-                            &state.syntax_set,
-                        )
-                        .map_err(|e| ErrorTemplate {
-                            state: tmpl_state.clone(),
-                            code: StatusCode::INTERNAL_SERVER_ERROR,
-                            message: format!("error highlighting markdown fenced code block: {e}",),
-                        })?;
+                            if extension.eq_ignore_ascii_case("md") {
+                                let displayed =
+                                    render_markdown_with_syntax_set(&contents, &state.syntax_set)
+                                        .map_err(|e| ErrorTemplate {
+                                        state: tmpl_state.clone(),
+                                        code: StatusCode::INTERNAL_SERVER_ERROR,
+                                        message: format!(
+                                            "error highlighting markdown fenced code block: {e}",
+                                        ),
+                                    })?;
 
-                        DisplayType::Markdown {
-                            highlighted,
-                            displayed,
+                                DisplayType::Markdown {
+                                    highlighted,
+                                    displayed,
+                                }
+                            } else {
+                                DisplayType::Text { highlighted }
+                            }
                         }
-                    } else {
-                        DisplayType::Text { highlighted }
+                        // Not valid UTF-8 text — offer it as a download rather
+                        // than crashing with a 500.
+                        Err(_) => DisplayType::Other,
                     }
                 }
             }


### PR DESCRIPTION
Fixes #24.

The `display` view read text/JSON uploads with `read_to_string`, which errors on any file that isn't valid UTF-8 — so viewing, say, a Latin-1 `.txt` returned a 500.

This reads the file with `read_to_end` and attempts a UTF-8 decode:
- valid UTF-8 → highlighted/rendered exactly as before;
- not UTF-8 → falls back to `DisplayType::Other`, the same generic view used for binary uploads, so the page loads and offers the raw download instead of crashing.

Chose the graceful-rejection path (over lossy re-encoding) so the displayed bytes always match the file. `cargo build`, `cargo clippy`, and `cargo +nightly fmt --check` all pass. I didn't see a handler-level test harness in the repo (only the `str_to_duration` unit tests), so I kept this minimal — happy to add a regression test if you have a preferred way to exercise the view handlers.